### PR TITLE
feat: add runs/ ledger schema

### DIFF
--- a/runs/.schema.yaml
+++ b/runs/.schema.yaml
@@ -1,0 +1,26 @@
+# Machine-readable run ledger schema.
+# Read by hekton-status and cross-project dashboard aggregators.
+# Generated 2026-07-01 by standardise-runs-ledger.py — re-run with --force to regenerate.
+schema_version: "1"
+project: ai-powered-turtle
+project_type: factory-output
+id_prefix: APT
+task_types:
+  - research-post
+  - prompt-kit
+  - blog-post
+  - tool-guide
+  - documentation
+run_description: "A published article, prompt kit, blog post, tool guide, or documentation page in the AI-powered Turtle knowledge lab"
+fields:
+  run_id: string
+  project: string
+  task_id: string
+  task_type: string
+  engine: string
+  status: "done | pending-response | in-progress | failed | abandoned"
+  created: date
+  human_confirmed: boolean
+  human_notes: string
+  output_artifact: string
+  failure_reason: string

--- a/runs/README.md
+++ b/runs/README.md
@@ -1,0 +1,55 @@
+# Run Ledger — AI Powered Turtle
+
+A published article, prompt kit, blog post, tool guide, or documentation page in the AI-powered Turtle knowledge lab
+
+Each run is a YAML file: `runs/run-YYYYMMDD-APT-NNN.yaml`
+
+## ID Prefix: `APT`
+
+Auto-increment from 001. Scan `runs/run-*-APT-*.yaml` for the next available number.
+
+## Task Types
+
+- `research-post`
+- `prompt-kit`
+- `blog-post`
+- `tool-guide`
+- `documentation`
+
+## Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `run_id` | string | `run-YYYYMMDD-APT-NNN` |
+| `project` | string | `ai-powered-turtle` |
+| `task_id` | string | `APT-NNN` |
+| `task_type` | string | See task types above |
+| `engine` | string | Who/what did the work (`claude-code`, `local-harness`, `human`, `script`, …) |
+| `status` | string | `done`, `pending-response`, `in-progress`, `failed`, `abandoned` |
+| `created` | date | ISO 8601 date |
+| `human_confirmed` | bool | `false` until a human reviews and approves the output |
+| `human_notes` | string | Optional review notes |
+| `output_artifact` | string | Path to output file or artefact |
+| `failure_reason` | string | Populated when status is `failed` |
+
+## Example Entry
+
+```yaml
+run_id: run-2026-07-01-APT-001
+project: ai-powered-turtle
+task_id: APT-001
+task_type: research-post
+engine: claude-code
+status: done
+created: "2026-07-01"
+human_confirmed: false
+human_notes: ""
+output_artifact: ""
+failure_reason: ""
+```
+
+## Notes
+
+- `human_confirmed: true` must be set by a human after reviewing the output — never by automation.
+- This ledger is read by `hekton-status.sh` for cross-project dashboard aggregation.
+- Re-generate: `just standardise-ledger -- --project ai-powered-turtle --force`


### PR DESCRIPTION
## Summary
- Adds `runs/README.md` and `runs/.schema.yaml` generated by standardise-runs-ledger.py
- Standardises the runs ledger pattern across all Hekton projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)