### PR TITLE
chore(adoption): adopt ai-powered-turtle into Hekton control plane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# AI Powered Turtle currently requires no project-specific environment variables
+# for local validation.
+#
+# If deployment or analytics variables are introduced later, document them here
+# with blank example values only. Never commit real credentials.

--- a/.hekton/agent-run-log.yaml
+++ b/.hekton/agent-run-log.yaml
@@ -1,0 +1,10 @@
+agent_run_log_version: 1
+project_name: ai-powered-turtle
+runs:
+  - date: 2026-06-04
+    agent: codex
+    role: existing-project-adoption-agent
+    summary: "Cloned repository to temporary intake, classified as factory-output, added Hekton control-plane artifacts, and prepared for permanent placement."
+    source_repo_url: "git@github.com:coderturtle/ai-powered-turtle.git"
+    temporary_intake_path: "/private/tmp/hekton-adoption/ai-powered-turtle"
+    permanent_path: "/Users/hekton/Development/hekton/factory-output/ai-powered-turtle"

--- a/.hekton/change-log.yaml
+++ b/.hekton/change-log.yaml
@@ -1,0 +1,22 @@
+change_log_version: 1
+project_name: ai-powered-turtle
+entries:
+  - date: 2026-06-04
+    agent: codex
+    change_type: adoption
+    summary: "Adopted existing coderturtle repository into the Hekton factory-output project tree."
+    files_changed:
+      - ".hekton/"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "CODEX.md"
+      - "docs/"
+      - "scripts/"
+      - "mind-palace/"
+      - ".env.example"
+    validation:
+      - "scripts/check-prereqs.sh: passed"
+      - "scripts/verify-project.sh: passed; npm checks skipped because dependencies are not installed"
+      - "just validate-reproducibility /Users/hekton/Development/hekton/factory-output/ai-powered-turtle: passed"
+      - "just governance-check /Users/hekton/Development/hekton/factory-output/ai-powered-turtle: passed"
+      - "just validate-taxonomy: passed; live vault has no factory-output control-plane entry yet"

--- a/.hekton/governance.yaml
+++ b/.hekton/governance.yaml
@@ -1,0 +1,44 @@
+governance_version: 1
+project_name: ai-powered-turtle
+created_date: 2026-06-04
+owner: hekton
+
+governance_level: G1
+autonomy_level: 3
+
+approval_policy:
+  destructive_changes: human_required
+  public_release: human_required
+  production_changes: human_required
+  credential_or_secret_changes: human_required
+  financial_changes: human_required
+  personal_data_changes: human_required
+  dependency_changes: human_required
+  deployment_changes: human_required
+
+required_gates:
+  preflight: true
+  intent_recorded: true
+  risk_review: true
+  reproducibility_review: true
+  validation_recorded: true
+  end_session_review: true
+  commit_hygiene_review: true
+
+minimum_artifacts:
+  project_metadata: ".hekton/project.yaml"
+  governance: ".hekton/governance.yaml"
+  risk_register: ".hekton/risk-register.yaml"
+  change_log: ".hekton/change-log.yaml"
+  review_log: ".hekton/review-log.yaml"
+  agent_run_log: ".hekton/agent-run-log.yaml"
+  session_log: "docs/session-log.md"
+  decisions: "docs/decisions.md"
+  risks: "docs/risks.md"
+
+agent_defaults:
+  safe_autonomy: true
+  stop_for_human_approval_when_risk_is_high: true
+  update_session_log_for_material_changes: true
+  prefer_dry_run_before_mutation: true
+  never_commit_secrets: true

--- a/.hekton/project.yaml
+++ b/.hekton/project.yaml
@@ -1,0 +1,73 @@
+project_name: ai-powered-turtle
+project_title: "AI Powered Turtle"
+classification: factory-output
+status: active
+lifecycle_stage: draft
+adoption_status: adopted
+local_repo_path: /Users/hekton/Development/hekton/factory-output/ai-powered-turtle
+mind_palace_path: 20-projects/factory-output/ai-powered-turtle
+owner: hekton
+created_date: 2026-06-04
+source_repo_url: "git@github.com:coderturtle/ai-powered-turtle.git"
+promotion_target: none
+privacy_boundary: public
+github_account: coderturtle
+github_remote_url: "git@github.com-coderturtle:coderturtle/ai-powered-turtle.git"
+vault_mutation_allowed: false
+version: ""
+
+default_agents:
+  - claude
+  - codex
+
+related_projects: []
+
+reproducibility:
+  target: "blank Hekton machine"
+  setup_mode: "scripted"
+  bootstrap_script: "scripts/bootstrap-project.sh"
+  prereq_script: "scripts/check-prereqs.sh"
+  verify_script: "scripts/verify-project.sh"
+  dry_run_supported: true
+  destructive_actions_allowed: false
+  env_file: ".env.example"
+  local_assumptions_doc: "docs/local-assumptions.md"
+  setup_doc: "docs/setup.md"
+  reproducibility_doc: "docs/reproducibility.md"
+  install_policy:
+    prefer_homebrew: true
+    prefer_documented_cli_commands: true
+    avoid_opaque_installers: true
+    require_manual_confirmation_for_unknown_installers: true
+
+architecture:
+  domain: factory-output
+  capability_area: knowledge-site
+  component_type: quartz-site
+  maturity_level: 2
+  maturity_label: working
+  maturity_set_by: agent
+  maturity_basis: adoption-audit
+  maturity_date: 2026-06-04
+  target_state_relevance: supporting
+  depends_on:
+    - quartz
+    - github-pages
+  enables:
+    - public-knowledge-site
+    - prompt-library
+    - research-publishing
+  consumes:
+    - obsidian-style-markdown
+  promotion_candidate: false
+  promotion_target: none
+  next_architecture_step: "Review content/privacy posture and decide whether this remains an actively maintained public factory output."
+  last_validated: 2026-06-04
+  evidence_links:
+    - README.md
+    - docs/project-walkthrough.md
+    - docs/adoption-checklist.md
+  risks:
+    - "The repository contains a large authored content tree that should be reviewed before further public publication."
+    - "The repo includes GitHub Actions workflows; adoption did not modify or revalidate deployment behavior."
+  owner: hekton

--- a/.hekton/review-log.yaml
+++ b/.hekton/review-log.yaml
@@ -1,0 +1,11 @@
+review_log_version: 1
+project_name: ai-powered-turtle
+reviews:
+  - date: 2026-06-04
+    reviewer: codex
+    review_type: adoption-audit
+    status: completed-with-caveats
+    summary: "Read-only intake review found a Quartz knowledge site with no obvious credential-shaped secrets, but with content/publication risks requiring human review."
+    follow_ups:
+      - "Review the content tree for publication/privacy suitability."
+      - "Review GitHub Actions deployment behavior before pushing adoption branch."

--- a/.hekton/risk-register.yaml
+++ b/.hekton/risk-register.yaml
@@ -1,0 +1,43 @@
+risk_register_version: 1
+project_name: ai-powered-turtle
+created_date: 2026-06-04
+
+risks:
+  - id: RISK-0001
+    title: "Large authored content tree needs publication review"
+    category: privacy
+    likelihood: medium
+    impact: high
+    status: open
+    owner: hekton
+    mitigation: "Review content/ before further public release or automated publishing changes."
+    raised_date: 2026-06-04
+    reviewed_date: 2026-06-04
+    links:
+      - "docs/risks.md"
+  - id: RISK-0002
+    title: "Deployment workflows were adopted without execution"
+    category: operations
+    likelihood: medium
+    impact: medium
+    status: open
+    owner: hekton
+    mitigation: "Review .github/workflows/ before changing deployment or pushing adoption branch upstream."
+    raised_date: 2026-06-04
+    reviewed_date: 2026-06-04
+    links:
+      - "docs/risks.md"
+  - id: RISK-0003
+    title: "Mixed upstream licensing context"
+    category: legal
+    likelihood: low
+    impact: medium
+    status: open
+    owner: hekton
+    mitigation: "Confirm whether Apache-2.0 LICENSE and Quartz MIT LICENSE.txt accurately describe code and content licensing."
+    raised_date: 2026-06-04
+    reviewed_date: 2026-06-04
+    links:
+      - "LICENSE"
+      - "LICENSE.txt"
+      - "docs/risks.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md - AI Powered Turtle
+
+## Project Classification
+
+This repository is a Hekton **factory-output** project.
+
+- Local repo path: `/Users/hekton/Development/hekton/factory-output/ai-powered-turtle`
+- Vault control-plane path: `20-projects/factory-output/ai-powered-turtle`
+- GitHub account: `coderturtle`
+- Privacy boundary: `public`
+- Vault mutation allowed: `false`
+
+## Operating Rules
+
+Before structural changes, read:
+
+- `.hekton/project.yaml`
+- `README.md`
+- `docs/project-walkthrough.md`
+- `docs/session-log.md`
+- `docs/decisions.md`
+- `docs/next-actions.md`
+- this file
+
+Agents must not write to the live Obsidian vault from this repo unless the human explicitly authorizes that write in the current session. Use the repo-local `mind-palace/` mirror for proposed notes.
+
+## Scope Boundaries
+
+This adoption commit must remain behavior-neutral. Do not modify Quartz source, content notes, dependency manifests, lockfiles, or GitHub Actions workflows unless a later task explicitly requests that work.
+
+For future sessions:
+
+- Keep authored content review separate from infrastructure work.
+- Treat deployment workflow changes as human-approved only.
+- Do not publish, push, or change remotes without explicit approval.
+- Run the cheapest relevant validation and record the result in `docs/session-log.md`.
+
+## Known Validation Commands
+
+```bash
+scripts/check-prereqs.sh
+scripts/verify-project.sh
+npm run check
+npm test
+```
+
+Run `npm` commands only after dependencies are installed and the human is comfortable with local package execution for this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md - AI Powered Turtle
+
+Follow `AGENTS.md` in this repository and the shared Hekton operating rules.
+
+This is an adopted factory-output project linked to the `coderturtle` GitHub account. Keep adoption, content review, deployment work, and feature work as separate sessions.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,5 @@
+# CODEX.md - AI Powered Turtle
+
+Follow `AGENTS.md` in this repository and the shared Hekton operating rules.
+
+For this project, Codex should default to read-first, behavior-neutral changes unless the human explicitly asks for implementation work.

--- a/docs/adoption-checklist.md
+++ b/docs/adoption-checklist.md
@@ -1,0 +1,86 @@
+# Existing Project Adoption Checklist - AI Powered Turtle
+
+Date: 2026-06-04
+Agent: Codex
+
+## Intake
+
+- [x] Source repo URL or local path: `git@github.com:coderturtle/ai-powered-turtle.git`
+- [x] Temporary intake path: `/private/tmp/hekton-adoption/ai-powered-turtle`
+- [x] Owner: `hekton`
+- [x] Expected purpose: public Quartz knowledge site for AI/software architecture notes, prompt kits, research, and project writeups.
+- [x] Privacy boundary: `public`
+- [x] Human wants original Git history preserved: yes, inferred from clone/adoption request.
+- [x] Upstream sync should remain possible: yes, origin kept as `git@github.com-coderturtle:coderturtle/ai-powered-turtle.git`.
+
+## Initial Inspection
+
+- [x] README reviewed.
+- [x] License reviewed or missing license recorded.
+- [x] Dependency manifests reviewed.
+- [x] Setup docs reviewed.
+- [x] `.gitignore` reviewed.
+- [x] Remotes reviewed.
+- [x] Recent Git history reviewed.
+- [x] Obvious generated or local-only files identified.
+- [x] Secrets risk scan performed.
+
+## Classification
+
+- [x] Classification selected: `factory-output`
+- [x] Rationale: the project is a personal/public deliverable made outside the Hekton factory machinery, not reusable Hekton platform infrastructure and not a Hekton experiment lab.
+- [x] Permanent local path: `/Users/hekton/Development/hekton/factory-output/ai-powered-turtle`
+- [x] Vault control-plane path: `20-projects/factory-output/ai-powered-turtle`
+- [x] Promotion target if lab: not applicable
+- [x] Canonical lifecycle stage: `draft`
+- [x] Adoption status: `adopted`
+
+## Risk Review
+
+- [x] License risk: medium, because both Apache-2.0 and MIT license files are present and content licensing should be clarified.
+- [x] Secrets risk: low based on credential-shaped pattern scan.
+- [x] Personal-data risk: medium until authored content is reviewed.
+- [x] Production risk: low.
+- [x] Dependency risk: medium until package audit/check runs.
+- [x] Remote/publication risk: medium because GitHub Actions deployment workflows exist.
+- [x] Risks recorded in docs and `.hekton` ledgers.
+
+## Hektonization
+
+- [x] `.hekton/project.yaml` created or updated.
+- [x] Governance files created or updated.
+- [x] `AGENTS.md` created or updated.
+- [x] `CLAUDE.md` created or updated.
+- [x] `CODEX.md` created or updated.
+- [x] `docs/session-log.md` updated.
+- [x] `docs/decisions.md` updated.
+- [x] `docs/operating-model.md` created or updated.
+- [x] `docs/project-walkthrough.md` created or updated.
+- [x] `docs/next-actions.md` updated.
+- [x] `docs/setup.md` created or updated.
+- [x] `docs/local-assumptions.md` created or updated.
+- [x] `docs/reproducibility.md` created or updated.
+- [x] `.env.example` created or confirmed not needed.
+- [x] Executable prereq, bootstrap, and verify scripts created.
+- [x] Repo-local `mind-palace/` mirror drafted.
+
+## Validation
+
+- [x] `just validate-taxonomy`
+- [x] `just validate-reproducibility /Users/hekton/Development/hekton/factory-output/ai-powered-turtle`
+- [x] `just governance-check /Users/hekton/Development/hekton/factory-output/ai-powered-turtle`
+- [ ] Project-specific tests or smoke checks: pending dependency install.
+
+## Mind Palace
+
+- [x] Repo-local mirror created.
+- [x] Live vault mutation approved: no
+- [x] Vault backup required before sync: yes
+- [x] Vault control-plane files proposed or synced: proposed only.
+
+## Handoff
+
+- [x] Handoff target: Review
+- [x] Immediate next action: review content and deployment workflow posture before pushing or publishing adoption branch.
+- [x] Open questions: clarify intended license posture for authored content versus Quartz code.
+- [x] Archive/reference-only decision needed: no

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,42 @@
+# Decisions
+
+## 2026-06-04 - Adopt as factory-output
+
+Status: Accepted
+
+### Context
+
+`ai-powered-turtle` is an existing Quartz/Obsidian-style knowledge site owned through the `coderturtle` GitHub handle. The user stated it is not directly part of the Hekton factory machinery.
+
+### Decision
+
+Adopt the repository as a Hekton `factory-output` project.
+
+- Local path: `/Users/hekton/Development/hekton/factory-output/ai-powered-turtle`
+- Vault path: `20-projects/factory-output/ai-powered-turtle`
+- Adoption status: `adopted`
+- Lifecycle stage: `draft`
+
+### Consequences
+
+- The repo must not use the `hekton-` prefix.
+- Product/code/content changes remain separate from the adoption commit.
+- Hekton control-plane files live in the repo, while live vault updates require explicit human approval.
+
+## 2026-06-04 - Record coderturtle as GitHub account
+
+Status: Accepted
+
+### Context
+
+Hekton has first-class GitHub account routing in `~/hekton/config/github-accounts.yaml`. Factory-output projects can use `coderturtle`, and the SSH alias `github.com-coderturtle` selects the correct key.
+
+### Decision
+
+Record `github_account: coderturtle` and `github_remote_url: git@github.com-coderturtle:coderturtle/ai-powered-turtle.git` in `.hekton/project.yaml`.
+
+### Consequences
+
+- Future validation can compare the registered account to the actual `origin` remote.
+- Agents should use the coderturtle SSH alias for this repo.
+- No central Hekton machinery change is needed for GitHub-handle routing.

--- a/docs/local-assumptions.md
+++ b/docs/local-assumptions.md
@@ -1,0 +1,8 @@
+# Local Assumptions
+
+- The repo is checked out at `/Users/hekton/Development/hekton/factory-output/ai-powered-turtle`.
+- The `coderturtle` SSH alias exists as `github.com-coderturtle`.
+- Node.js 20 or newer is available.
+- npm is available and should be preferred because `package-lock.json` is tracked.
+- The content tree is intended to be public, but needs human review before further publishing changes.
+- Live Obsidian vault writes require explicit human approval.

--- a/docs/next-actions.md
+++ b/docs/next-actions.md
@@ -1,0 +1,7 @@
+# Next Actions
+
+- [ ] Review `content/` for publication, privacy, and personal-data suitability.
+- [ ] Review `.github/workflows/` before pushing adoption changes upstream.
+- [ ] Clarify license posture for authored content versus Quartz code.
+- [ ] Run dependency install and project checks if local execution is approved.
+- [ ] Decide whether to sync `mind-palace/` proposals into the live vault.

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -1,0 +1,51 @@
+# Operating Model
+
+## Purpose
+
+AI Powered Turtle is a Quartz-powered public knowledge site for AI architecture notes, prompt kits, research, dashboards, and project writeups.
+
+Within Hekton, it is a factory-output project: a deliverable produced or maintained by the broader Hekton operating environment, not part of the Hekton factory machinery itself.
+
+## Ownership And Routing
+
+- Hekton classification: `factory-output`
+- GitHub account: `coderturtle`
+- Remote: `git@github.com-coderturtle:coderturtle/ai-powered-turtle.git`
+- Local path: `/Users/hekton/Development/hekton/factory-output/ai-powered-turtle`
+- Vault path: `20-projects/factory-output/ai-powered-turtle`
+
+## Maintenance Rules
+
+- Keep adoption, content edits, infrastructure edits, and deployment changes as separate sessions.
+- Do not change `.github/workflows/` without explicit human approval.
+- Do not install or upgrade dependencies as part of unrelated work.
+- Review authored content before public publishing or deployment changes.
+- Update `docs/session-log.md`, `docs/decisions.md`, and `docs/next-actions.md` after material sessions.
+
+## Validation
+
+Cheapest Hekton checks:
+
+```bash
+scripts/check-prereqs.sh
+scripts/verify-project.sh
+```
+
+Project checks, after dependencies are installed:
+
+```bash
+npm run check
+npm test
+```
+
+Central Hekton checks:
+
+```bash
+cd /Users/hekton/hekton
+just validate-reproducibility /Users/hekton/Development/hekton/factory-output/ai-powered-turtle
+just governance-check -- /Users/hekton/Development/hekton/factory-output/ai-powered-turtle
+```
+
+## Vault Policy
+
+Live vault mutation is not allowed by default. Draft proposed control-plane notes in `mind-palace/` and sync only after explicit human approval and the normal backup/sync process.

--- a/docs/project-walkthrough.md
+++ b/docs/project-walkthrough.md
@@ -1,0 +1,48 @@
+# Project Walkthrough
+
+## What This Is
+
+AI Powered Turtle is a public knowledge site built with Quartz. It turns an Obsidian-style Markdown content tree into a browsable web site.
+
+The repo contains two broad things:
+
+- The Quartz site machinery: TypeScript, Quartz configuration, static assets, package manifests, and GitHub Actions workflows.
+- The authored knowledge base: prompts, research notes, whitepapers, project writeups, dashboards, and scratch notes under `content/`.
+
+## Why It Matters
+
+This is a factory output rather than Hekton machinery. It is useful as a published body of work and a place where AI/software architecture thinking can be organized for readers outside the Hekton operating system.
+
+## How It Fits Hekton
+
+Hekton keeps code and deliverables under `/Users/hekton/Development/hekton/`. Because this repo is linked to the `coderturtle` GitHub handle and is not Hekton platform infrastructure, it belongs under:
+
+```text
+/Users/hekton/Development/hekton/factory-output/ai-powered-turtle
+```
+
+Its human-facing control plane should live under:
+
+```text
+20-projects/factory-output/ai-powered-turtle
+```
+
+The live vault has not been changed in this adoption session. The `mind-palace/` folder contains proposed mirror files only.
+
+## What Was Verified
+
+- The repository cloned successfully through the coderturtle SSH alias.
+- The remote is configured as `git@github.com-coderturtle:coderturtle/ai-powered-turtle.git`.
+- The README, licenses, package manifest, `.gitignore`, recent commits, and tracked files were inspected.
+- A credential-shaped secret scan found no obvious token/key/private-key hits.
+
+## What Remains Unverified
+
+- The content tree has not been fully reviewed for publication/privacy suitability.
+- GitHub Actions deployment behavior has not been executed or reviewed in detail.
+- Dependencies were not installed during adoption.
+- `npm run check` and `npm test` have not been run.
+
+## Human Next Step
+
+Review whether this repo should remain public-facing as-is, then decide whether to push the adoption branch back to GitHub.

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,0 +1,23 @@
+# Reproducibility
+
+## Target
+
+The project should be reproducible on a blank Hekton machine with Node.js 20+ and npm 9.3.1+.
+
+## Scripts
+
+- `scripts/check-prereqs.sh`: verifies local tool availability.
+- `scripts/bootstrap-project.sh`: installs npm dependencies.
+- `scripts/verify-project.sh`: performs lightweight structural checks and runs npm validation when dependencies are present.
+
+## Rebuild Flow
+
+```bash
+scripts/check-prereqs.sh
+scripts/bootstrap-project.sh
+scripts/verify-project.sh
+```
+
+## Notes
+
+The adoption session did not install dependencies or run project-specific checks. That should happen in a later session after content/publication posture is reviewed.

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -1,0 +1,19 @@
+# Risks
+
+## RISK-0001 - Large Authored Content Tree Needs Publication Review
+
+Status: open
+
+The repository contains many Markdown notes under `content/`, including research, prompts, whitepapers, project writeups, dashboards, and scratch material. Review this content before further publication or automated deployment changes.
+
+## RISK-0002 - Deployment Workflows Were Adopted Without Execution
+
+Status: open
+
+The repository includes GitHub Actions workflows. Adoption did not execute or alter them. Review workflow behavior before pushing adoption changes upstream.
+
+## RISK-0003 - Mixed Upstream Licensing Context
+
+Status: open
+
+Both `LICENSE` and `LICENSE.txt` are present. The project should clarify whether Apache-2.0 applies to authored content, whether MIT applies to Quartz-derived code, and how public reuse should be described.

--- a/docs/session-log.md
+++ b/docs/session-log.md
@@ -1,0 +1,73 @@
+# Session Log
+
+## 2026-06-04 - Hekton adoption
+
+### Changed Files
+
+- `.hekton/project.yaml`: added Hekton metadata, taxonomy classification, GitHub account metadata, reproducibility metadata, and architecture-map metadata.
+- `.hekton/governance.yaml`: added governance baseline and approval rules.
+- `.hekton/risk-register.yaml`: recorded adoption risks for content review, deployment workflows, and licensing.
+- `.hekton/change-log.yaml`: recorded the adoption change.
+- `.hekton/review-log.yaml`: recorded the read-only adoption audit.
+- `.hekton/agent-run-log.yaml`: recorded the Codex adoption run.
+- `AGENTS.md`, `CLAUDE.md`, `CODEX.md`: added project-specific agent instructions.
+- `.env.example`: documented that no local environment variables are currently required.
+- `docs/adoption-checklist.md`: recorded the existing-project adoption checklist.
+- `docs/decisions.md`: recorded classification and GitHub account decisions.
+- `docs/operating-model.md`: described the operating model for maintaining the project under Hekton.
+- `docs/project-walkthrough.md`: added a plain-English explanation of the project and adoption.
+- `docs/next-actions.md`: added immediate follow-up actions.
+- `docs/setup.md`, `docs/local-assumptions.md`, `docs/reproducibility.md`: added setup and reproducibility notes.
+- `docs/risks.md`: added human-readable risk register.
+- `scripts/check-prereqs.sh`, `scripts/bootstrap-project.sh`, `scripts/verify-project.sh`: added conservative reproducibility scripts.
+- `mind-palace/`: drafted repo-local control-plane mirror files.
+
+### What Changed
+
+The existing `coderturtle/ai-powered-turtle` repository was cloned into a temporary Hekton adoption intake path, inspected, classified as `factory-output`, and given Hekton governance, traceability, setup, and proposed mind-palace artifacts.
+
+### Why It Changed
+
+The project is unrelated to Hekton factory machinery but belongs in the Hekton project tree as a personal/public factory output linked to the `coderturtle` GitHub handle.
+
+### Decisions Made
+
+- Classification: `factory-output`.
+- Permanent path: `/Users/hekton/Development/hekton/factory-output/ai-powered-turtle`.
+- Vault path: `20-projects/factory-output/ai-powered-turtle`.
+- GitHub account: `coderturtle`, recorded explicitly in `.hekton/project.yaml`.
+- Live vault mutation: not performed; repo-local `mind-palace/` files are proposals only.
+
+### Assumptions Made
+
+- Original Git history should be preserved.
+- Upstream sync should remain possible through the coderturtle SSH alias.
+- The repository remains public-facing unless a later content review changes the privacy boundary.
+
+### Risks
+
+- The content tree should be reviewed before further publication or automation.
+- GitHub Actions workflows exist and were not executed or changed during adoption.
+- License posture should be clarified because both Apache-2.0 and MIT license files are present.
+
+### Next Actions
+
+- Review `content/` for public/privacy suitability.
+- Review `.github/workflows/` before pushing adoption changes upstream.
+- Clarify license posture for authored content versus Quartz code.
+- Run project-specific dependency validation after dependency install is approved.
+
+### Validation Status
+
+- Intake clone: passed.
+- Read-only credential-shaped secret scan: no obvious hits.
+- `scripts/check-prereqs.sh`: passed.
+- `scripts/verify-project.sh`: passed; npm checks skipped because dependencies are not installed.
+- `just validate-reproducibility /Users/hekton/Development/hekton/factory-output/ai-powered-turtle`: passed.
+- `just governance-check /Users/hekton/Development/hekton/factory-output/ai-powered-turtle`: passed.
+- `just validate-taxonomy`: passed; live vault has no factory-output control-plane entry yet because vault sync was not authorized.
+- Project-specific tests: not run; dependencies were not installed during adoption audit.
+
+### Mind-Palace Updated
+
+Proposed only. Live vault was not changed.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,41 @@
+# Setup
+
+## Prerequisites
+
+- Node.js 20 or newer
+- npm 9.3.1 or newer
+
+Check prerequisites:
+
+```bash
+scripts/check-prereqs.sh
+```
+
+## Install
+
+```bash
+npm install
+```
+
+The repository contains `package-lock.json`, so use npm unless a later decision changes the package manager.
+
+## Verify
+
+```bash
+scripts/verify-project.sh
+```
+
+After dependencies are installed, run:
+
+```bash
+npm run check
+npm test
+```
+
+## Build
+
+```bash
+npm run quartz -- build
+```
+
+The README also documents `bun install` and `bun run build`; the current `package.json` and lockfile point to npm as the safer reproducible default for this Hekton adoption.

--- a/mind-palace/decisions.md
+++ b/mind-palace/decisions.md
@@ -1,0 +1,7 @@
+# Decisions
+
+## 2026-06-04 - Adopt as factory-output
+
+Adopt `ai-powered-turtle` as a Hekton `factory-output` project linked to the `coderturtle` GitHub account.
+
+Live vault sync is not approved in this session.

--- a/mind-palace/index.md
+++ b/mind-palace/index.md
@@ -1,0 +1,16 @@
+---
+project_name: ai-powered-turtle
+project_title: AI Powered Turtle
+classification: factory-output
+lifecycle_stage: draft
+local_repo_path: /Users/hekton/Development/hekton/factory-output/ai-powered-turtle
+mind_palace_path: 20-projects/factory-output/ai-powered-turtle
+github_account: coderturtle
+vault_mutation_allowed: false
+---
+
+# AI Powered Turtle
+
+AI Powered Turtle is a Quartz-powered public knowledge site for AI architecture notes, prompt kits, research, dashboards, and project writeups.
+
+This repo-local note is a proposed mind-palace mirror. It has not been synced to the live vault.

--- a/mind-palace/next-actions.md
+++ b/mind-palace/next-actions.md
@@ -1,0 +1,5 @@
+# Next Actions
+
+- [ ] Review content/publication posture.
+- [ ] Review GitHub Actions deployment workflows.
+- [ ] Decide whether to sync this mirror into the live vault.

--- a/mind-palace/session-log.md
+++ b/mind-palace/session-log.md
@@ -1,0 +1,7 @@
+# Session Log
+
+## 2026-06-04 - Hekton adoption
+
+Cloned the existing `coderturtle/ai-powered-turtle` repository, classified it as `factory-output`, added Hekton control-plane artifacts, and prepared proposed mind-palace notes.
+
+Live vault was not changed.

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+scripts/check-prereqs.sh
+
+if [[ ! -f package-lock.json ]]; then
+  echo "package-lock.json is missing; refusing to install dependencies without a lockfile."
+  exit 1
+fi
+
+npm install
+
+echo "Bootstrap complete."

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+failures=0
+
+check_cmd() {
+  local cmd="$1"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    echo "ok: $cmd found"
+  else
+    echo "missing: $cmd"
+    failures=$((failures + 1))
+  fi
+}
+
+check_cmd node
+check_cmd npm
+check_cmd git
+
+if command -v node >/dev/null 2>&1; then
+  node_major="$(node -v | sed 's/^v//' | cut -d. -f1)"
+  if [[ "$node_major" -lt 20 ]]; then
+    echo "missing: node version must be 20 or newer"
+    failures=$((failures + 1))
+  fi
+fi
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "Prerequisite check failed with $failures issue(s)."
+  exit 1
+fi
+
+echo "Prerequisite check passed."

--- a/scripts/verify-project.sh
+++ b/scripts/verify-project.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+failures=0
+
+check_file() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    echo "ok: $path"
+  else
+    echo "missing: $path"
+    failures=$((failures + 1))
+  fi
+}
+
+check_dir() {
+  local path="$1"
+  if [[ -d "$path" ]]; then
+    echo "ok: $path/"
+  else
+    echo "missing: $path/"
+    failures=$((failures + 1))
+  fi
+}
+
+check_file ".hekton/project.yaml"
+check_file "README.md"
+check_file "package.json"
+check_file "package-lock.json"
+check_file "quartz.config.ts"
+check_file "quartz.layout.ts"
+check_dir "content"
+check_dir "quartz"
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "Structural verification failed with $failures issue(s)."
+  exit 1
+fi
+
+if [[ -d node_modules ]]; then
+  npm run check
+  npm test
+else
+  echo "node_modules not present; skipped npm run check and npm test."
+fi
+
+echo "Verification complete."


### PR DESCRIPTION
## Summary
- Adds Hekton governance metadata: `.hekton/project.yaml`, `governance.yaml`, `risk-register.yaml`, `agent-run-log.yaml`
- Adds full doc-contract set: `CLAUDE.md`, `AGENTS.md`, `CODEX.md`, `docs/` (session-log, decisions, next-actions, walkthrough, setup, risks, operating-model, reproducibility, adoption-checklist, local-assumptions)
- Adds `mind-palace/` vault control plane mirror
- Adds bootstrap scripts: `check-prereqs.sh`, `bootstrap-project.sh`, `verify-project.sh`
- Adds `.env.example`

## What this does
Brings `ai-powered-turtle` under Hekton's taxonomy and doc-contract so it is visible to `hekton-status`, `validate-taxonomy`, and the mirror-gremlin sync.

## Test plan
- [ ] `just validate-taxonomy` passes
- [ ] `just validate-agent-docs` passes
- [ ] `just hekton-status` shows the project when it has run entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)